### PR TITLE
create-root at config to avoid too many calls

### DIFF
--- a/inc/WireCellRoot/MagnifySink.h
+++ b/inc/WireCellRoot/MagnifySink.h
@@ -39,7 +39,7 @@ namespace WireCell {
             IAnodePlane::pointer m_anode;
 
 	    int m_nrebin;
-
+	    void create_file();
 	    void do_shunt(TFile* output_tf);
 
             Log::logptr_t log;

--- a/src/MagnifySink.cxx
+++ b/src/MagnifySink.cxx
@@ -50,6 +50,8 @@ void Root::MagnifySink::configure(const WireCell::Configuration& cfg)
     m_cfg = cfg;
 
     m_nrebin = get<int>(cfg, "nrebin", m_nrebin);
+
+    create_file();
 }
 
 
@@ -181,6 +183,15 @@ std::vector<WireCell::Binning> collate_byplane(const ITrace::vector& traces, con
         }
     }
     return binnings;
+}
+
+void Root::MagnifySink::create_file() {
+  const std::string ofname = m_cfg["output_filename"].asString();
+  const std::string mode = "RECREATE";
+  TFile* output_tf = TFile::Open(ofname.c_str(), mode.c_str());
+  output_tf->Close("R");
+  delete output_tf;
+  output_tf = nullptr;
 }
 
 

--- a/src/RootfileCreation.cxx
+++ b/src/RootfileCreation.cxx
@@ -23,6 +23,7 @@ Root::RootfileCreation_depos::~RootfileCreation_depos(){
 void Root::RootfileCreation_depos::configure(const WireCell::Configuration& cfg)
 {
   m_cfg = cfg;
+  create_file();
 }
 
 WireCell::Configuration Root::RootfileCreation_depos::default_configuration() const
@@ -42,7 +43,6 @@ bool Root::RootfileCreation_depos::operator()(const WireCell::IDepo::pointer& in
     std::cerr << "RootfileCreation_depos: EOS\n";
     return true;
   }
-  create_file();
   return true;
 }
 
@@ -66,6 +66,7 @@ Root::RootfileCreation_frames::~RootfileCreation_frames(){
 void Root::RootfileCreation_frames::configure(const WireCell::Configuration& cfg)
 {
   m_cfg = cfg;
+  create_file();
 }
 
 WireCell::Configuration Root::RootfileCreation_frames::default_configuration() const
@@ -96,7 +97,6 @@ bool Root::RootfileCreation_frames::operator()(const WireCell::IFrame::pointer& 
     std::cerr << "RootfileCreation_frames: EOS\n";
     return true;
   }
-  create_file();
   return true;
 }
  


### PR DESCRIPTION
We (@czczc @goowenq @HaiwangYu ) noticed [a sim check macro](https://github.com/WireCell/wire-cell-cfg/blob/master/pgrapher/experiment/pdsp/wct-sim-check.jsonnet) for pDUNE runs rather slow due to IO limitation. The `RootfileCreation_depos` is to blame for this. This has been discussed by @weihythu @brettviren and others before. The `create_file()` was called too many times since it was in the `INode::operator()`

Timing results before this pull request:

![image](https://user-images.githubusercontent.com/10383186/62901946-1466c180-bd2c-11e9-808e-8328a5cda6a2.png)

The above results are obtained with solid hard drive. Running with a spinning disk would make this even worse.

After discussion with @brettviren , we moved the root-file-creation, `create_file()`, to the `IConfigurable::configure` interface which should be only called once using the current `Main` app. This also guarantees the root file recreated so the `MagnifySink` could continue to run in `Update` mode without duplications.

Further, since the `RootfileCreation_depos` and `RootfileCreation_frames` are solely purposed for the root-file-creation. We could move this functionality to the `MagnifySink` and completely remove the `RootfileCreation_*` classes.

Timing results after this change:

![image](https://user-images.githubusercontent.com/10383186/62901987-3102f980-bd2c-11e9-9b5c-13dab764abee.png)

 - Note: the `create_file()` functions are moved to the `IConfigurable::configure` for both `RootfileCreation_*` and `MagnifySink` in this pull request. This will improve current jsonnet macros using `RootfileCreation_*` without any changes. In the future, the `RootfileCreation_*` could be removed, and the root files should be recreated correctly at the beginning of each job.


